### PR TITLE
Fix some logging code failed to work and refine log format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# user config
+config.user.yml

--- a/README.md
+++ b/README.md
@@ -36,11 +36,20 @@ cd jd_AutoComment
 pip install -r requirements.txt
 ```
 
-获取电脑版ck后填入 `config.yml` 文件：
+获取电脑版ck后填入配置文件。可以选择填入默认配置文件 `config.yml` ；也可以填入用户配置文件 `config.user.yml` （需要新建后将 `config.yml` 中的内容复制到该文件中），避免后续的更新覆盖 `config.yml` 中的内容。
+
+需要填入如下内容：
 
 ```yml
 user:
-  cookie: ''
+  cookie: '<Cookie>'
+```
+
+例如，若获取得到的ck为 `a=1; b=2; c=3` ，则配置文件中填入：
+
+```yml
+user:
+  cookie: 'a=1; b=2; c=3'
 ```
 
 最后运行 `auto_comment_plus.py` ：
@@ -56,11 +65,15 @@ python3 auto_comment_plus.py
 本程序支持命令行参数：
 
 ```text
-usage: auto_comment_plus.py [-h] [--dry-run]
+usage: auto_comment_plus.py [-h] [--dry-run] [--log-level LOG_LEVEL] [-o LOG_FILE]
 
 optional arguments:
-  -h, --help  show this help message and exit
-  --dry-run   have a full run without comment submission
+  -h, --help            show this help message and exit
+  --dry-run             have a full run without comment submission
+  --log-level LOG_LEVEL
+                        specify logging level (default: info)
+  -o LOG_FILE, --log-file LOG_FILE
+                        specify logging file
 ```
 
 **`-h`, `--help`:**
@@ -70,6 +83,16 @@ optional arguments:
 **`--dry-run`:**
 
 完整地运行程序，但不实际提交评论。
+
+**`--log-level LOG_LEVEL`:**
+
+设置输出日志的等级。默认为 `INFO` 。可选等级为 `DEBUG`、`INFO`、`WARNING`、`ERROR` ，输出内容量依次递减。
+
+**注意:** 若你需要提交 issue 来报告一个 bug ，请将该选项设置为 `DEBUG` 。
+
+**`-o LOG_FILE`:**
+
+设置输出日志文件的路径。若无此选项，则不输出到文件。
 
 ## 声明
 

--- a/auto_comment_plus.py
+++ b/auto_comment_plus.py
@@ -6,6 +6,7 @@
 import argparse
 import copy
 import logging
+import os
 import random
 import sys
 import time
@@ -20,6 +21,7 @@ import jdspider
 
 # constants
 CONFIG_PATH = './config.yml'
+USER_CONFIG_PATH = './config.user.yml'
 ORDINARY_SLEEP_SEC = 10
 SUNBW_SLEEP_SEC = 5
 REVIEW_SLEEP_SEC = 10
@@ -641,6 +643,7 @@ if __name__ == '__main__':
     logger.debug('Options passed to functions: %s', opts)
     logger.debug('Builtin constants:')
     logger.debug('  CONFIG_PATH: %s', CONFIG_PATH)
+    logger.debug('  USER_CONFIG_PATH: %s', USER_CONFIG_PATH)
     logger.debug('  ORDINARY_SLEEP_SEC: %s', ORDINARY_SLEEP_SEC)
     logger.debug('  SUNBW_SLEEP_SEC: %s', SUNBW_SLEEP_SEC)
     logger.debug('  REVIEW_SLEEP_SEC: %s', REVIEW_SLEEP_SEC)
@@ -648,7 +651,13 @@ if __name__ == '__main__':
 
     # parse configurations
     logger.debug('Reading the configuration file')
-    with open(CONFIG_PATH, 'r', encoding='utf-8') as f:
+    if os.path.exists(USER_CONFIG_PATH):
+        logger.debug('User configuration file exists')
+        _cfg_path = USER_CONFIG_PATH
+    else:
+        logger.debug('User configuration file doesn\'t exist, fallback to the default one')
+        _cfg_path = CONFIG_PATH
+    with open(_cfg_path, 'r', encoding='utf-8') as f:
         cfg = yaml.safe_load(f)
     logger.debug('Closed the configuration file')
     logger.debug('Configurations in Python-dict format: %s', cfg)

--- a/auto_comment_plus.py
+++ b/auto_comment_plus.py
@@ -246,7 +246,7 @@ def ordinary(N, opts=None):
             url2 = "https://club.jd.com/myJdcomments/saveProductComment.action"
             opts['logger'].debug('URL: %s', url2)
             xing, Str = generation(oname, opts=opts)
-            opts['logger'].info(f'\t\t评价内容,星级{xing}：', Str)
+            opts['logger'].info(f'\t\t评价内容,星级{xing}：' + Str)
             data2 = {
                 'orderId': oid,
                 'productId': pid,  # 商品id
@@ -260,7 +260,8 @@ def ordinary(N, opts=None):
                 opts['logger'].debug('Sending comment request')
                 pj2 = requests.post(url2, headers=headers, data=data2)
             else:
-                opts['logger'].debug('Skipped sending comment request in dry run')
+                opts['logger'].debug(
+                    'Skipped sending comment request in dry run')
             opts['logger'].debug('Sleep time (s): %.1f', ORDINARY_SLEEP_SEC)
             time.sleep(ORDINARY_SLEEP_SEC)
             idx += 1
@@ -519,7 +520,7 @@ def Service_rating(N, opts=None):
             pj1 = requests.post(url1, headers=headers, data=data1)
         else:
             opts['logger'].debug('Skipped sending comment request in dry run')
-        opts['logger'].info("\t\t", pj1.text)
+        opts['logger'].info("\t\t " + pj1.text)
         opts['logger'].debug('Sleep time (s): %.1f', SERVICE_RATING_SLEEP_SEC)
         time.sleep(SERVICE_RATING_SLEEP_SEC)
         N['服务评价'] -= 1
@@ -530,8 +531,8 @@ def No(opts=None):
     opts = opts or {}
     opts['logger'].info('')
     N = all_evaluate(opts)
-    for i in N:
-        opts['logger'].info('{} {}----'.format(i, N[i]))
+    s = '----'.join(['{} {}'.format(i, N[i]) for i in N])
+    opts['logger'].info(s)
     opts['logger'].info('')
     return N
 


### PR DESCRIPTION
As is in issue #18, this commit fixes some logging code failed to work.

That's because `Logger.<debug|info|warning|error>()` has a similar but
different parameter form from that of `print()`. The method of `Logger`
needs the positional arguments other than the first one to be contents
of the `%`-like templates in the first `str` argument, but that's very
different from `print()`'s behavior.

And this commit refines format of some logging code.