### PR TITLE
Make all loggers consistent

### DIFF
--- a/auto_comment_plus.py
+++ b/auto_comment_plus.py
@@ -11,6 +11,7 @@ import random
 import sys
 import time
 
+import jieba  # just for linting
 import jieba.analyse
 import requests
 import yaml
@@ -610,7 +611,6 @@ if __name__ == '__main__':
 
     # logging on console
     _logging_level = getattr(logging, opts['log_level'])
-    jieba.setLogLevel(_logging_level)
     logger = logging.getLogger(__name__)
     logger.setLevel(level=_logging_level)
     # NOTE: `%(levelname)s` will be parsed as the original name (`FATAL` ->
@@ -625,6 +625,9 @@ if __name__ == '__main__':
     console.setFormatter(formatter)
     logger.addHandler(console)
     opts['logger'] = logger
+    # It's a hack!
+    jieba.default_logger = logger
+    jieba.default_logger.name = 'jieba'
 
     logger.debug('Successfully set up console logger')
     logger.debug('CLI arguments: %s', args)

--- a/auto_comment_plus.py
+++ b/auto_comment_plus.py
@@ -611,7 +611,7 @@ if __name__ == '__main__':
 
     # logging on console
     _logging_level = getattr(logging, opts['log_level'])
-    logger = logging.getLogger(__name__)
+    logger = logging.getLogger('comment')
     logger.setLevel(level=_logging_level)
     # NOTE: `%(levelname)s` will be parsed as the original name (`FATAL` ->
     # `CRITICAL`, `WARN` -> `WARNING`).
@@ -625,9 +625,10 @@ if __name__ == '__main__':
     console.setFormatter(formatter)
     logger.addHandler(console)
     opts['logger'] = logger
-    # It's a hack!
-    jieba.default_logger = logger
-    jieba.default_logger.name = 'jieba'
+    # It's a hack!!!
+    jieba.default_logger = logging.getLogger('jieba')
+    jieba.default_logger.setLevel(level=_logging_level)
+    jieba.default_logger.addHandler(console)
 
     logger.debug('Successfully set up console logger')
     logger.debug('CLI arguments: %s', args)
@@ -642,6 +643,7 @@ if __name__ == '__main__':
         handler.setLevel(_logging_level)
         handler.setFormatter(rawformatter)
         logger.addHandler(handler)
+        jieba.default_logger.addHandler(handler)
         logger.debug('Successfully set up file logger')
     logger.debug('Options passed to functions: %s', opts)
     logger.debug('Builtin constants:')

--- a/auto_comment_plus.py
+++ b/auto_comment_plus.py
@@ -629,6 +629,10 @@ if __name__ == '__main__':
     jieba.default_logger = logging.getLogger('jieba')
     jieba.default_logger.setLevel(level=_logging_level)
     jieba.default_logger.addHandler(console)
+    # It's another hack!!!
+    jdspider.default_logger = logging.getLogger('spider')
+    jdspider.default_logger.setLevel(level=_logging_level)
+    jdspider.default_logger.addHandler(console)
 
     logger.debug('Successfully set up console logger')
     logger.debug('CLI arguments: %s', args)
@@ -644,6 +648,7 @@ if __name__ == '__main__':
         handler.setFormatter(rawformatter)
         logger.addHandler(handler)
         jieba.default_logger.addHandler(handler)
+        jdspider.default_logger.addHandler(handler)
         logger.debug('Successfully set up file logger')
     logger.debug('Options passed to functions: %s', opts)
     logger.debug('Builtin constants:')


### PR DESCRIPTION
`jieba` and `JDSpider` had their own `logging.Logger`s with certainly different formats and actions from those of the customized one we have made. This pull request aims to make all the loggers consistent. It directly replaces the built-in loggers inside the external modules with that in `auto_comment_plus.py`.

These three loggers have different names. They will be used to log in the future.