### PR TITLE
change encode type of cookie

### DIFF
--- a/auto_comment_plus.py
+++ b/auto_comment_plus.py
@@ -674,7 +674,7 @@ if __name__ == '__main__':
     ck = cfg['user']['cookie']
 
     headers = {
-        'cookie': ck,
+        'cookie': ck.encode("utf-8"),
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.82 Safari/537.36',
         'Connection': 'keep-alive',
         'Cache-Control': 'max-age=0',


### PR DESCRIPTION
If nick name has chinese characters, requests.get(url, headers=headers) will throw an error。